### PR TITLE
Add explicit token permissions to the build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: build
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
The build workflow does not declare any permissions, so `GITHUB_TOKEN` is issued with whatever the repository default happens to be. Code scanning flags this, and the workflow does not need it: it only reads the repository, and the image pushes authenticate against Docker Hub with `DOCKER_HUB_TOKEN` rather than with the GitHub token.

After this change the token is limited to `contents: read`.