### PR TITLE
Update CI actions to current majors and Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: set up go 1.23
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.23'
-      id: go
-
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
+
+    - name: set up go 1.26
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26'
+      id: go
 
     # - name: build and test
     #   run: |


### PR DESCRIPTION
Bumps `actions/checkout` and `actions/setup-go` from v4 to v7, and the Go version the workflow installs from 1.23 to 1.26. Checkout now runs before setup-go, because setup-go caches modules by default and needs `go.sum` to be present to do so.

The builder image in the Dockerfile, which is what actually compiles the binary, is bumped to match in #4.