### PR TITLE
Exit promptly and cleanly on a shutdown signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -42,7 +43,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx); err != nil {
+	// cancellation means the shutdown signal was received, not a failure
+	if err := run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatalf("[ERROR] run failed: %v", err)
 	}
 	log.Printf("[INFO] completed")
@@ -53,16 +55,16 @@ func main() {
 func run(ctx context.Context) error {
 	if opts.SkipCheck {
 		if err := startRetrans(ctx); err != nil {
-			return fmt.Errorf("failed to start retranslation: %w", err)
+			return shutdownErr(ctx, fmt.Errorf("failed to start retranslation: %w", err))
 		}
 		if !checkStreamStatus(ctx) {
-			return fmt.Errorf("stream is not available")
+			return shutdownErr(ctx, fmt.Errorf("stream is not available"))
 		}
 		return nil
 	}
 
 	for {
-		// cancel the context if the parent is done
+		// don't start a new cycle on a cancelled context
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -71,14 +73,31 @@ func run(ctx context.Context) error {
 
 		if checkStreamStatus(ctx) {
 			log.Print("[INFO] Stream is available, start retranslation")
-			if err := startRetrans(ctx); err != nil {
+			if err := startRetrans(ctx); err != nil && ctx.Err() == nil {
 				log.Printf("[WARN] failed to start retranslation: %v", err)
 			}
 		} else {
 			log.Printf("[DEBUG] Not streaming, next check in %v", opts.CheckInterval)
 		}
-		time.Sleep(opts.CheckInterval)
+
+		// wait for the next check, interruptible by the shutdown signal
+		timer := time.NewTimer(opts.CheckInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
+}
+
+// shutdownErr replaces err with the context error if ctx is done, so the caller
+// can tell an intended shutdown from a real failure
+func shutdownErr(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }
 
 // checkStreamStatus checks if the stream is available
@@ -92,7 +111,9 @@ func checkStreamStatus(ctx context.Context) bool {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("[WARN] Can't get response from %s: %v", opts.CheckURL, err)
+		if ctx.Err() == nil { // stay quiet if the request was interrupted by the shutdown
+			log.Printf("[WARN] Can't get response from %s: %v", opts.CheckURL, err)
+		}
 		return false
 	}
 	defer resp.Body.Close()
@@ -104,7 +125,9 @@ func checkStreamStatus(ctx context.Context) bool {
 
 	data := map[string]any{}
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		log.Printf("[WARN] Failed to decode response: %v", err)
+		if ctx.Err() == nil {
+			log.Printf("[WARN] Failed to decode response: %v", err)
+		}
 		return false
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunStopsWhileWaitingForTheNextCheck(t *testing.T) {
+	checked := make(chan struct{}, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case checked <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusNotFound) // not streaming, run goes straight to the wait
+	}))
+	defer ts.Close()
+
+	saved := opts
+	opts.CheckURL = ts.URL
+	opts.CheckInterval = time.Hour
+	opts.CheckTimeout = time.Second
+	opts.SkipCheck = false
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	t.Cleanup(func() {
+		cancel()
+		waitDone(t, done)
+		opts = saved
+	})
+
+	go func() {
+		done <- run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-checked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not make the status check")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("run did not return within 5s of cancellation, check interval is %v", opts.CheckInterval)
+	}
+}
+
+func TestRunReportsKilledRetranslationAsCancellation(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	ffmpeg := filepath.Join(dir, "ffmpeg")
+	script := "#!/bin/sh\ntouch '" + ready + "'\nexec sleep 60\n" // exec, so the killed shell takes sleep with it
+	if err := os.WriteFile(ffmpeg, []byte(script), 0o700); err != nil {
+		t.Fatalf("can't write the fake ffmpeg: %v", err)
+	}
+
+	saved := opts
+	opts.SkipCheck = true
+	opts.FfmpegPath = ffmpeg
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	t.Cleanup(func() {
+		cancel()
+		waitDone(t, done)
+		opts = saved
+	})
+
+	go func() {
+		done <- run(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the fake ffmpeg did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		// the killed process reports "signal: killed", main must not treat it as a failure
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after the retranslation was cancelled")
+	}
+}
+
+// waitDone waits for run to return, so the options it reads can be restored safely
+func waitDone(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Error("run is still going after cancellation")
+	}
+}


### PR DESCRIPTION
Previously, the polling loop slept through the whole check interval with `time.Sleep`, so SIGINT or SIGTERM arriving during the wait was noticed only after up to a full interval, 60 seconds by default. That is long enough for a container runtime to escalate to SIGKILL. Once the loop did wake up, `run` returned `ctx.Err()` and `main` passed it to `log.Fatalf`, so an intended shutdown ended with exit status 1.

After this change the wait is a timer selected against `ctx.Done()`, so the process reacts to the signal immediately. Errors caused by the cancellation are reported as the context error, `main` exits normally on it, and neither the killed ffmpeg process nor the interrupted status check is logged as a warning any more.

`main_test.go` covers both paths: cancellation while waiting for the next check, and cancellation while a retranslation is running. Both tests fail against the current master.